### PR TITLE
fix: typo

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -14,7 +14,7 @@ fvm install 3.3.2 /// ここまででOK
 
 cd プロジェクト内
 
-fvm flutter use 3.3.2
+fvm use 3.3.2
 ```
 
 ### 環境構築


### PR DESCRIPTION
`fvm flutter use 3.3.2`をすると
`Could not find a command named "use".`
で怒られた

## issue (PRと紐づける場合は Closes #数字)


## やったこと


## やらないこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認


## その他
